### PR TITLE
Fix mapping of JSON unit/settlement data

### DIFF
--- a/src/data/initialSettlements.js
+++ b/src/data/initialSettlements.js
@@ -3,7 +3,7 @@ import rawSettlements from './settlements.json';
 import Settlement from '../models/Settlement';
 
 export const allSettlements = rawSettlements.map(s => new Settlement({
-  id:                       s.ID,
+  id:                       s['Settlement ID'],
   type:                     s.Type,
   tier:                     s.Tier,
   faction:                  s.Faction,
@@ -15,11 +15,11 @@ export const allSettlements = rawSettlements.map(s => new Settlement({
   buildingLimit:            s['Building Limit'],
   zoneOfControl:            s['Zone of Control'],
   resourcesPerAdjacentTile: s['Resources per adjacent tile'],
-  yieldFood:                s.Food,
-  yieldWood:                s.Wood,
-  yieldMetal:               s.Metal,
-  costGold:                 s.Gold,
-  costFood:                 s['Food.1'],
-  costWood:                 s['Wood.1'],
-  costMetal:                s['Metal.1']
+  yieldFood:                s['Food flat'] || 0,
+  yieldWood:                s['Wood flat'] || 0,
+  yieldMetal:               s['Metal flat'] || 0,
+  costGold:                 Number(s.Gold) || 0,
+  costFood:                 Number(s.Food) || 0,
+  costWood:                 Number(s.Wood) || 0,
+  costMetal:                Number(s.Metal) || 0
 }));

--- a/src/data/initialUnits.js
+++ b/src/data/initialUnits.js
@@ -7,22 +7,22 @@ import Unit from '../models/Unit';
  * from your Excel → JSON data.
  */
 export const allUnits = rawUnits.map(u => new Unit({
-  id:             u.ID,
+  id:             u['Unit ID'],
   type:           u.Type,
   tier:           u.Tier,
   faction:        u.Faction,
   hp:             u.HP,
-  specialRange:   u.SpecialRange ?? 0,
+  specialRange:   Number(u['Special range roll']) || 0,
   range:          u.Range ?? 0,
-  rangedRoll:     u['Ranged roll']        || '',
+  rangedRoll:     u['Ranged Roll']        || '',
   offensiveRoll:  u['Offensive Roll']     || '',
   defensiveRoll:  u['Defensive Roll']     || '',
   cost: {
-    gold:       u.Gold     || 0,
-    food:       u.Food     || 0,
-    wood:       u.Wood     || 0,
-    metal:      u.Metal    || 0,
-    crystal:    u.Crystal  || 0,
-    population: u.Population || 0,
+    gold:       Number(u['Gold Cost'])       || 0,
+    food:       Number(u['Food Cost'])       || 0,
+    wood:       Number(u['Wood Cost'])       || 0,
+    metal:      Number(u['Metal Cost'])      || 0,
+    crystal:    Number(u['Crystal Cost'])    || 0,
+    population: Number(u['Population Cost']) || 0,
   }
 }));


### PR DESCRIPTION
## Summary
- correct JSON property names when building initial unit and settlement objects
- normalize NA/number fields when reading costs and yields

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68529483edf08328b29ca1ba6b3d6bd1