### PR TITLE
Add basic AI simulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "simulate": "node src/game/runSimpleSimulation.js"
   },
   "eslintConfig": {
     "extends": [

--- a/src/AI/SimpleAI.js
+++ b/src/AI/SimpleAI.js
@@ -1,0 +1,67 @@
+const rawUnits = require('../data/units.json');
+const allUnits = rawUnits.map(u => ({
+  type: u.Type,
+  cost: {
+    gold: u['Gold Cost'] || u.Gold || 0,
+    food: u['Food Cost'] || u.Food || 0,
+    wood: u['Wood Cost'] || u.Wood || 0,
+    metal: u['Metal Cost'] || u.Metal || 0,
+    crystal: u['Crystal Cost'] || u.Crystal || 0,
+  }
+}));
+
+const STRATEGIES = {
+  AGGRESSIVE: 'aggressive',
+  DEFENSIVE: 'defensive',
+  BALANCED: 'balanced',
+};
+
+class SimpleAI {
+  constructor(playerId, strategy = STRATEGIES.BALANCED) {
+    this.playerId = playerId;
+    this.strategy = strategy;
+  }
+
+  takeTurn(engine) {
+    this._build(engine);
+    this._move(engine);
+  }
+
+  _build(engine) {
+    const player = engine.players[this.playerId];
+    const unitType = 'Soldier';
+    const unitData = allUnits.find(u => u.type === unitType);
+    const cost = unitData ? unitData.cost : { gold: 4, food: 2, wood: 2, metal: 0, crystal: 0 };
+    if (!engine.canAfford(player, cost)) return;
+    for (let r = 0; r < engine.rows; r++) {
+      for (let c = 0; c < engine.cols; c++) {
+        const tile = engine.getTile(r, c);
+        if (tile && !tile.unit) {
+          engine.spawnUnit(this.playerId, unitType, r, c);
+          return;
+        }
+      }
+    }
+  }
+
+  _move(engine) {
+    const player = engine.players[this.playerId];
+    for (const unit of player.units) {
+      const target = this._findAdjacentFree(engine, unit);
+      if (target) engine.moveUnit(unit, target.row, target.col);
+    }
+  }
+
+  _findAdjacentFree(engine, unit) {
+    const dirs = [ [1,0], [-1,0], [0,1], [0,-1] ];
+    for (const [dr, dc] of dirs) {
+      const r = unit.row + dr;
+      const c = unit.col + dc;
+      const tile = engine.getTile(r, c);
+      if (tile && !tile.unit) return { row: r, col: c };
+    }
+    return null;
+  }
+}
+
+module.exports = { SimpleAI, STRATEGIES };

--- a/src/game/GameEngine.js
+++ b/src/game/GameEngine.js
@@ -1,0 +1,79 @@
+const { makeInitialTiles } = require('../data/initialTiles');
+const rawUnits = require('../data/units.json');
+const allUnits = rawUnits.map(u => ({
+  type: u.Type,
+  cost: {
+    gold: u['Gold Cost'] || u.Gold || 0,
+    food: u['Food Cost'] || u.Food || 0,
+    wood: u['Wood Cost'] || u.Wood || 0,
+    metal: u['Metal Cost'] || u.Metal || 0,
+    crystal: u['Crystal Cost'] || u.Crystal || 0,
+  },
+}));
+
+class GameEngine {
+  constructor({ players = 2, rows = 10, cols = 10 } = {}) {
+    this.rows = rows;
+    this.cols = cols;
+    this.tiles = makeInitialTiles(rows, cols);
+    this.turn  = 1;
+
+    this.players = Array.from({ length: players }, (_, id) => ({
+      id,
+      resources: { gold: 10, food: 10, wood: 10, metal: 0, crystal: 0 },
+      units: []
+    }));
+
+    this.units = [];
+  }
+
+  getTile(row, col) {
+    return this.tiles[row] && this.tiles[row][col];
+  }
+
+  canAfford(player, cost) {
+    return Object.entries(cost).every(([k, v]) => (player.resources[k] || 0) >= v);
+  }
+
+  spendResources(player, cost) {
+    for (const [k, v] of Object.entries(cost)) {
+      player.resources[k] = (player.resources[k] || 0) - v;
+    }
+  }
+
+  /**
+   * Place a unit on the board if the tile is free and the player can afford it.
+   * Returns the new unit or null on failure.
+   */
+  spawnUnit(playerId, unitType, row, col) {
+    const tile = this.getTile(row, col);
+    if (!tile || tile.unit) return null;
+    const unitData = allUnits.find(u => u.type === unitType);
+    if (!unitData) return null;
+    const player = this.players[playerId];
+    if (!this.canAfford(player, unitData.cost)) return null;
+    this.spendResources(player, unitData.cost);
+    const unit = { ...unitData, owner: playerId, row, col };
+    tile.unit = unit;
+    player.units.push(unit);
+    this.units.push(unit);
+    return unit;
+  }
+
+  moveUnit(unit, targetRow, targetCol) {
+    const target = this.getTile(targetRow, targetCol);
+    if (!target || target.unit) return false;
+    const current = this.getTile(unit.row, unit.col);
+    if (current) current.unit = null;
+    target.unit = unit;
+    unit.row = targetRow;
+    unit.col = targetCol;
+    return true;
+  }
+
+  nextTurn() {
+    this.turn += 1;
+  }
+}
+
+module.exports = GameEngine;

--- a/src/game/runSimpleSimulation.js
+++ b/src/game/runSimpleSimulation.js
@@ -1,0 +1,14 @@
+const GameEngine = require('./GameEngine');
+const { SimpleAI, STRATEGIES } = require('../AI/SimpleAI');
+
+const engine = new GameEngine({ players: 2, rows: 5, cols: 5 });
+const ai1 = new SimpleAI(0, STRATEGIES.AGGRESSIVE);
+const ai2 = new SimpleAI(1, STRATEGIES.AGGRESSIVE);
+
+for (let i = 0; i < 3; i++) {
+  ai1.takeTurn(engine);
+  ai2.takeTurn(engine);
+  engine.nextTurn();
+}
+
+console.log(JSON.stringify(engine, null, 2));


### PR DESCRIPTION
## Summary
- implement a small `GameEngine` for unit placement and movement
- add a very simple AI (`SimpleAI`) that spawns and moves Soldiers
- provide a node script `runSimpleSimulation.js` and npm script `simulate`

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run simulate --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852953fd8588328a1a374170c13e8ac