### PR TITLE
Fix hex board display

### DIFF
--- a/src/components/HexBoard.jsx
+++ b/src/components/HexBoard.jsx
@@ -3,9 +3,11 @@ import React from 'react';
 import HexTile from './HexTile';
 
 export default function HexBoard({ tiles, units, settlements, onTileClick }) {
+  const flatTiles = Array.isArray(tiles[0]) ? tiles.flat() : tiles;
+
   return (
     <svg width="600" height="600">
-      {tiles.map(tile => (
+      {flatTiles.map((tile) => (
         <HexTile
           key={`${tile.row},${tile.col}`}
           tile={tile}


### PR DESCRIPTION
## Summary
- fix hex board rendering by flattening nested tiles

## Testing
- `CI=true npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852cb163dbc8328ab38767cab04536a