### PR TITLE
Allow selection from all factions

### DIFF
--- a/src/components/FactionSelect.jsx
+++ b/src/components/FactionSelect.jsx
@@ -10,7 +10,8 @@ export default function FactionSelect({ players, onBack, onSelect }) {
     'The Amethyst Enclave',
     'The Farheed Commonwealth',
   ];
-  const factions = ALL_FACTIONS.slice(0, players);
+  // Show all factions regardless of player count
+  const factions = ALL_FACTIONS;
   return (
     <div className="home">
       <h1>Select Your Faction</h1>

--- a/src/components/__tests__/FactionSelect.test.js
+++ b/src/components/__tests__/FactionSelect.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FactionSelect from '../FactionSelect';
+
+test('shows all factions regardless of player count', () => {
+  render(<FactionSelect players={2} onBack={() => {}} onSelect={() => {}} />);
+  expect(screen.getByText('The Amethyst Enclave')).toBeInTheDocument();
+  expect(screen.getByText('The Farheed Commonwealth')).toBeInTheDocument();
+  // 6 faction buttons + back button
+  const buttons = screen.getAllByRole('button');
+  expect(buttons).toHaveLength(7);
+});


### PR DESCRIPTION
## Summary
- show every faction in selection screen
- test FactionSelect to ensure all factions are visible

## Testing
- `CI=true npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_6852d2d6bea883288b9f0ad9ac827eb7