### PR TITLE
Fix hex layout and add terrain colors

### DIFF
--- a/src/components/HexTile.jsx
+++ b/src/components/HexTile.jsx
@@ -14,17 +14,19 @@ export default function HexTile({ tile, units, settlements, onTileClick }) {
 
   // build the 6-point polygon
   const points = Array.from({ length: 6 }).map((_, i) => {
-    const angle = Math.PI / 180 * (60 * i - 30);
+    const angle = Math.PI / 180 * (60 * i);
     const px = size * Math.cos(angle) + size;
     const py = size * Math.sin(angle) + size;
     return `${px},${py}`;
   }).join(' ');
 
   const terrainColors = {
-    plains:   '#D2B48C',
-    forest:   '#228B22',
-    mountain: '#A9A9A9',
-    water:    '#87CEFA',
+    plains:   '#c2b280', // darkish yellow
+    caves:    '#800080', // purple
+    farmland: '#98fb98', // light green
+    forest:   '#228B22', // dark green
+    mountain: '#A9A9A9', // silver/grey
+    water:    '#87CEFA', // blue
   };
   const fill = terrainColors[terrain] || '#EEE';
 

--- a/src/data/initialTiles.js
+++ b/src/data/initialTiles.js
@@ -1,10 +1,12 @@
 // generate an empty rows×cols grid
 export function makeInitialTiles(rows = 10, cols = 10) {
+  const terrains = ['plains', 'caves', 'farmland', 'forest', 'mountain', 'water'];
   const tiles = [];
   for (let r = 0; r < rows; r++) {
     const row = [];
     for (let c = 0; c < cols; c++) {
-      row.push({ row: r, col: c, terrain: 'plains',  unit: null });
+      const terrain = terrains[Math.floor(Math.random() * terrains.length)];
+      row.push({ row: r, col: c, terrain, unit: null });
     }
     tiles.push(row);
   }


### PR DESCRIPTION
## Summary
- correct hex orientation so hexes line up
- support six terrain types with distinct colors
- generate initial tiles with random terrain

## Testing
- `npm test --silent -- --runTestsByPath src/components/__tests__/FactionSelect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6852d511c53c83289a32d4122282a487