### PR TITLE
Implement dynamic board sizing and starting placement

### DIFF
--- a/src/components/HexBoard.jsx
+++ b/src/components/HexBoard.jsx
@@ -2,19 +2,39 @@
 import React from 'react';
 import HexTile from './HexTile';
 
-export default function HexBoard({ tiles, units, settlements, onTileClick }) {
+export default function HexBoard({
+  tiles,
+  units,
+  settlements,
+  onTileClick,
+  rows = 10,
+  cols = 10,
+  highlightTiles = [],
+}) {
   const flatTiles = Array.isArray(tiles[0]) ? tiles.flat() : tiles;
 
+  const size = 30;
+  const hexWidth = size * 2;
+  const hexHeight = (Math.sqrt(3) / 2) * hexWidth;
+  const boardWidth = hexWidth + (cols - 1) * size * 1.5;
+  const boardHeight = hexHeight * rows + hexHeight / 2;
+
+  const isHighlighted = (r, c) =>
+    highlightTiles.some((t) => t.row === r && t.col === c);
+
   return (
-    <svg width="600" height="600">
+    <svg width={boardWidth} height={boardHeight} style={{ userSelect: 'none' }}>
       {flatTiles.map((tile) => (
-        <HexTile
-          key={`${tile.row},${tile.col}`}
-          tile={tile}
-          units={units}
-          settlements={settlements}
-          onTileClick={onTileClick}
-        />
+        <g key={`${tile.row},${tile.col}`}
+           opacity={isHighlighted(tile.row, tile.col) ? 0.6 : 1}
+        >
+          <HexTile
+            tile={tile}
+            units={units}
+            settlements={settlements}
+            onTileClick={onTileClick}
+          />
+        </g>
       ))}
     </svg>
   );


### PR DESCRIPTION
## Summary
- compute width/height in `HexBoard` so larger boards display properly
- add starting zone logic and placement helpers in `GameEngine`
- highlight selectable tiles and set up first‑turn placement in `GameScreen`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852d7424a64832891a5c9ffdff17509